### PR TITLE
fix for regular user login, staff fix still needed

### DIFF
--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -14,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, strategyId) {
     private readonly configService: ConfigService,
   ) {
     super({
-      configService: ConfigService,
+      // configService: ConfigService,
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: configService.get('jwt.secret'),
     });
@@ -28,17 +28,17 @@ export class JwtStrategy extends PassportStrategy(Strategy, strategyId) {
     iat: number;
     exp: number;
   }) {
+    console.log('$payload', payload);
     const id = payload.userId;
     const user = await this.userService.findById(id);
+
+    console.log('$user', user);
 
     if (!user) {
       throw new UnauthorizedException();
     }
 
-    if (
-      user.lastPasswordChange &&
-      user.lastPasswordChange.getTime() > payload.iat * 1000
-    ) {
+    if (user.lastPasswordChange && user.lastPasswordChange.getTime() > payload.iat * 1000) {
       throw new UnauthorizedException();
     }
 

--- a/src/metrics/metrics.controller.ts
+++ b/src/metrics/metrics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, HttpException, HttpStatus } from '@nestjs/common';
 import { MetricsService } from './metrics.service';
 import { MetricsDto, DashboardCostFormulaDto } from './dto/metrics';
 import { ApiResponse, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
@@ -17,9 +17,7 @@ export class MetricsController {
     status: 200,
     description: 'Metrics for the given period',
   })
-  async getMetrics(
-    @Query('period') period: 'current_week' | 'last_week' | 'last_month',
-  ) {
+  async getMetrics(@Query('period') period: 'current_week' | 'last_week' | 'last_month') {
     const periodDto: MetricsDto = { option: period };
     return this.metricsService.getMetrics(periodDto);
   }
@@ -31,6 +29,10 @@ export class MetricsController {
     description: 'Cost formula metrics for dashboard display',
   })
   async getDashboardCostMetrics(@User() user: UserEntity) {
+    if (!user || !user.id) {
+      throw new HttpException('User not found', HttpStatus.UNAUTHORIZED);
+    }
+
     return await this.metricsService.calculateCostSavings(user.id);
   }
 }


### PR DESCRIPTION
Original issue:
- Data wasn't being properly scoped to the current user
- All records were being returned (chat threads, documents) regardless of which user was logged in
- Error "Cannot read properties of undefined (reading 'id')" when trying to access user.id
- User context was missing from requests

Solution that fixed regular user context:
- Enabled the global JwtAuthGuard in main.ts which was previously commented out
- Marked public routes with @Public() decorator to allow login/registration
- Removed the StaffJwtAuthGuard from the global guards
- This restored proper user context so req.user and user.id were available
- Chat threads and documents are now properly filtered by user ID

What needs to be done for staff:
- Staff routes need to use the @StaffOnly() decorator or explicit @UseGuards(StaffJwtAuthGuard)
- Need to make sure staff/admin endpoints specifically require staff authentication
- May need to update the StaffJwtAuthGuard implementation
</think>

# Authentication Issues and Solutions Summary

## Original Issue
Your application was experiencing a critical authentication problem:
- Requests weren't receiving user context (req.user was undefined)
- Data wasn't being properly filtered by user ID
- All users' data was visible to everyone (chat threads, documents, etc.)
- Error "Cannot read properties of undefined (reading 'id')" in metrics controller
- The JWT strategy logs weren't appearing in the console

## Root Cause
The global authentication guards in main.ts were commented out:
```typescript
// These guards were commented out
// app.useGlobalGuards(
//   new JwtAuthGuard(reflector),
//   new StaffJwtAuthGuard(reflector),
// );
```

This meant:
1. No authentication was being enforced globally
2. Controller methods without explicit @UseGuards had no authentication
3. The JWT validation process wasn't running, so no user context was attached to requests
4. Database queries weren't being filtered by user ID, returning all records

## Solution That Fixed Regular User Access
1. Re-enabled the global JwtAuthGuard (but not the StaffJwtAuthGuard):
   ```typescript
   app.useGlobalGuards(new JwtAuthGuard(reflector));
   ```

2. Ensured login/registration routes were marked with @Public()

3. Removed redundant @UseGuards(JwtAuthGuard) from methods since it's now global

This fixed:
- User context is now properly attached to requests
- Chat threads and DocHub documents are properly filtered by user ID
- The "Cannot read properties of undefined" error is resolved

## What Needs to Be Done for Staff Routes
For staff/admin functionality to work:

1. **Apply StaffJwtAuthGuard only on admin routes**:
   ```typescript
   @Get('admin/endpoint')
   @UseGuards(StaffJwtAuthGuard)
   adminEndpoint() { ... }
   ```
   
2. **Or better, use the StaffOnly decorator**:
   ```typescript
   @Get('admin/endpoint')
   @StaffOnly()
   adminEndpoint() { ... }
   ```

3. **Update any controllers that incorrectly import Public from Prisma**:
   ```typescript
   // Wrong import
   import { Public } from '@prisma/client/runtime/library';
   
   // Correct import
   import { Public } from 'src/auth/decorators/public.decorator';
   ```

4. **Test staff login flows** to ensure staff users can access their appropriate routes

This approach provides proper authentication and authorization while maintaining a clean separation between regular user and admin functionality.
