### PR TITLE
Fixed notifications endpoint bug

### DIFF
--- a/src/notifications/controllers/notifications.controller.ts
+++ b/src/notifications/controllers/notifications.controller.ts
@@ -15,9 +15,9 @@ export class NotificationsController {
     @Request() req,
     @Query() payload: NotificationsFilterParamsDto,
   ) {
+    console.log(req);
     return await this.notificationsService.getStaffNotifications(
-      payload,
-      req?.user?.id,
+      payload
     );
   }
 

--- a/src/notifications/dto/query-notifications.dto.ts
+++ b/src/notifications/dto/query-notifications.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, IntersectionType } from '@nestjs/swagger';
 import { PaginationParams } from '../../types/pagination';
-import { IsEnum, IsOptional } from 'class-validator';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { notificationCategoryEnum } from '../enum/notifications.enum';
 
 export class NotificationsFilterParamsDto extends IntersectionType(
@@ -13,4 +13,12 @@ export class NotificationsFilterParamsDto extends IntersectionType(
   @IsOptional()
   @IsEnum(notificationCategoryEnum)
   category?: notificationCategoryEnum;
+  
+  @ApiProperty({
+    description: 'User ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  userId?: string;
 }

--- a/src/notifications/services/notifications.service.ts
+++ b/src/notifications/services/notifications.service.ts
@@ -14,12 +14,11 @@ export class NotificationsService {
   constructor(private readonly prisma: PrismaService) {}
 
   async getStaffNotifications(
-    payload: NotificationsFilterParamsDto,
-    staffUserId: string,
+    payload: NotificationsFilterParamsDto
   ) {
     const { page, limit } = payload;
 
-    let filter: Prisma.NotificationsStaffWhereInput = { staffId: staffUserId };
+    let filter: Prisma.NotificationsStaffWhereInput = { staffId: payload.userId };
     if (payload.category) {
       filter = {
         ...filter,


### PR DESCRIPTION
The endpoint to query the NotificationsStaff table had a bug in the way it was expecting the userId to be received in the request. Moved the userId to the request params and updated the types to match.

Query was failing before this change.